### PR TITLE
Update to 3.2.0

### DIFF
--- a/rpm/htop.spec
+++ b/rpm/htop.spec
@@ -1,6 +1,6 @@
 Name:       htop
 Summary:    Interactive process viewer
-Version:    3.0.2
+Version:    3.2.0
 Release:    1
 License:    GPLv2+
 URL:        https://htop.dev/
@@ -49,3 +49,4 @@ rm -Rvf %{buildroot}%{_mandir}/man1
 %defattr(-,root,root,-)
 %{_datadir}/applications/htop.desktop
 %{_datadir}/icons/hicolor/128x128/apps/htop.png
+%{_datadir}/icons/hicolor/scalable/apps/htop.svg

--- a/rpm/proper-icon-location.patch
+++ b/rpm/proper-icon-location.patch
@@ -1,13 +1,13 @@
 diff --git a/Makefile.am b/Makefile.am
-index e033c35..fedf5e0 100644
+index 8af1864..cc6ea80 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -9,7 +9,7 @@ EXTRA_DIST = $(dist_man_MANS) htop.desktop htop.png scripts/MakeHeader.py \
- install-sh autogen.sh missing
+@@ -19,7 +19,7 @@ EXTRA_DIST = \
+ 	build-aux/missing
  applicationsdir = $(datadir)/applications
  applications_DATA = htop.desktop
 -pixmapdir = $(datadir)/pixmaps
 +pixmapdir = $(datadir)/icons/hicolor/128x128/apps
  pixmap_DATA = htop.png
- 
- AM_CFLAGS += -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
+ appicondir = $(datadir)/icons/hicolor/scalable/apps
+ appicon_DATA = htop.svg

--- a/rpm/run-with-fingerterm.patch
+++ b/rpm/run-with-fingerterm.patch
@@ -1,8 +1,8 @@
 diff --git a/htop.desktop b/htop.desktop
-index 13b71e7..d3f9bb4 100644
+index 20bed49..0785231 100644
 --- a/htop.desktop
 +++ b/htop.desktop
-@@ -31,7 +31,7 @@ Comment[uk]=Перегляд системних процесів
+@@ -61,7 +61,7 @@ Comment[uk]=Перегляд системних процесів
  Comment[zh_CN]=显示系统进程
  Comment[zh_TW]=顯示系統行程
  Icon=htop

--- a/rpm/show-alternative-keys-in-functionbar.patch
+++ b/rpm/show-alternative-keys-in-functionbar.patch
@@ -1,34 +1,55 @@
+diff --git a/CommandLine.c b/CommandLine.c
+index d21f482..3d97608 100644
+--- a/CommandLine.c
++++ b/CommandLine.c
+@@ -118,6 +118,7 @@ static CommandLineStatus parseArguments(const char* program, int argc, char** ar
+       {"no-unicode", no_argument,         0, 'U'},
+       {"tree",       no_argument,         0, 't'},
+       {"pid",        required_argument,   0, 'p'},
++      {"alt-keys",   no_argument,         0, 'a'},
+       {"filter",     required_argument,   0, 'F'},
+       {"highlight-changes", optional_argument, 0, 'H'},
+       {"readonly",   no_argument,         0, 128},
+@@ -131,6 +132,9 @@ static CommandLineStatus parseArguments(const char* program, int argc, char** ar
+       if (opt == EOF)
+          break;
+       switch (opt) {
++         case 'a':
++            FunctionBar_useAltKeys(true);
++            break;
+          case 'h':
+             printHelpFlag(program);
+             return STATUS_OK_EXIT;
 diff --git a/FunctionBar.c b/FunctionBar.c
-index 659f410..113b499 100644
+index 0850037..9c0e056 100644
 --- a/FunctionBar.c
 +++ b/FunctionBar.c
-@@ -15,6 +15,12 @@ typedef struct FunctionBar_ {
- #include <stdlib.h>
- 
+@@ -17,6 +17,11 @@ in the source distribution for its full text.
+ #include "ProvideCurses.h"
+ #include "XUtils.h"
  
 +static bool AltKeys = false;
 +static const char* Alt_FunctionBar_FKeys[] = {" h", " S", " /", " \\", " t", " >", " ]", " [", " k", " q", NULL};
 +void FunctionBar_useAltKeys(bool use_alt_keys) {
 +   AltKeys = use_alt_keys;
 +}
-+
+ 
  static const char* const FunctionBar_FKeys[] = {"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", NULL};
  
- static const char* const FunctionBar_FLabels[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", NULL};
-@@ -51,7 +57,7 @@ FunctionBar* FunctionBar_new(const char** functions, const char** keys, int* eve
+@@ -56,7 +61,7 @@ FunctionBar* FunctionBar_new(const char* const* functions, const char* const* ke
        this->size = i;
     } else {
        this->staticData = true;
--      this->keys = (char**) FunctionBar_FKeys;
-+      this->keys = AltKeys ? (char**) Alt_FunctionBar_FKeys : (char**) FunctionBar_FKeys;
+-      this->keys.constKeys = FunctionBar_FKeys;
++      this->keys.constKeys = AltKeys ? Alt_FunctionBar_FKeys : FunctionBar_FKeys;
        this->events = FunctionBar_FEvents;
-       this->size = 10;
+       this->size = ARRAYSIZE(FunctionBar_FEvents);
     }
 diff --git a/FunctionBar.h b/FunctionBar.h
-index 1975fa3..bf2cac4 100644
+index f01a5ef..2ca77a0 100644
 --- a/FunctionBar.h
 +++ b/FunctionBar.h
-@@ -17,6 +17,8 @@ typedef struct FunctionBar_ {
+@@ -21,6 +21,8 @@ typedef struct FunctionBar_ {
     bool staticData;
  } FunctionBar;
  
@@ -37,25 +58,3 @@ index 1975fa3..bf2cac4 100644
  FunctionBar* FunctionBar_newEnterEsc(const char* enter, const char* esc);
  
  FunctionBar* FunctionBar_new(const char* const* functions, const char* const* keys, const int* events);
-diff --git a/htop.c b/htop.c
-index 239b5d6..be7b1f4 100644
---- a/htop.c
-+++ b/htop.c
-@@ -93,6 +93,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
-       {"no-unicode", no_argument,         0, 'U'},
-       {"tree",       no_argument,         0, 't'},
-       {"pid",        required_argument,   0, 'p'},
-+      {"alt-keys",   no_argument,         0, 'a'},
-       {0,0,0,0}
-    };
- 
-@@ -101,6 +102,9 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
-    while ((opt = getopt_long(argc, argv, "hvmCs:td:u::Up:", long_opts, &opti))) {
-       if (opt == EOF) break;
-       switch (opt) {
-+         case 'a':
-+            FunctionBar_useAltKeys(true);
-+            break;
-          case 'h':
-             printHelpFlag();
-             break;


### PR DESCRIPTION
Current version 3.0.2 is getting old-ish.

This PR proposes a version bump.

Upstream currently has three newer candidates available: 3.0.5, 3.1.2, and 3.2.0.

The branch this PR is based from contains the history of updating to each of those.

The fork also has the branches `htop-3.0`, and `htop-3.1` which have history of updating to the latest minor-minor of that version only.
Each of the branches has a tag for easy building and merging.

This should allow for the most conservative update you deem useful.

I have done basic testing for each of them under SFOS 4.2 on arm(32), all appear to work fine.

There are builds for testing available at:

 - 3.2: https://build.sailfishos.org/package/show/home:nephros:sailfishos/htop
 - 3.1: https://build.sailfishos.org/package/show/home:nephros:branches:home:nephros:sailfishos/htop-3.1
 - 3.0: https://build.sailfishos.org/package/show/home:nephros:branches:home:nephros:sailfishos/htop-3.0